### PR TITLE
Fix CURLOPT_FOLLOWLOCATION error for PHP in safe_mode and/or with open_basedir enabled.

### DIFF
--- a/fields/field.html_panel.php
+++ b/fields/field.html_panel.php
@@ -82,9 +82,9 @@
 
 			$ch = curl_init($url);
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-			// If safe_mode and/or open_basedir is enabled, CURLOPT_FOLLOWLOCATION is not allowed and throws error.
-			// So set it with errors disabled (by using "@" :).
-			@curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+			if(ini_get('safe_mode') == 0 && ini_get('open_basedir') == '') {
+				curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+			}
 			curl_setopt( $ch, CURLOPT_COOKIE, $cookie);
 			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
 			$result = curl_exec($ch);


### PR DESCRIPTION
Fix CURLOPT_FOLLOWLOCATION error: Panel stopped working for me because of CURLOPT_FOLLOWLOCATION error. I am not sure if it was  because of update to Symphony 2.2.1 (error handling was changed a bit, so it could start catching this one) or server changes (shared account, no control over full setup).
